### PR TITLE
fix garbled file's title on leftfovers.

### DIFF
--- a/dist/application.gs
+++ b/dist/application.gs
@@ -487,7 +487,7 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
  */
 GDriveService.prototype.downloadFile = function(id) {
   return this.throttle(function() {
-    return DriveApp.getFileById(propertiesDocId).getBlob().getDataAsString();
+    return DriveApp.getFileById(id).getBlob().getDataAsString();
   });
 };
 

--- a/dist/application.gs
+++ b/dist/application.gs
@@ -487,7 +487,7 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
  */
 GDriveService.prototype.downloadFile = function(id) {
   return this.throttle(function() {
-    return Drive.Files.get(id, { alt: 'media' });
+    return DriveApp.getFileById(propertiesDocId).getBlob().getDataAsString();
   });
 };
 

--- a/lib/GDriveService.js
+++ b/lib/GDriveService.js
@@ -68,7 +68,7 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
  */
 GDriveService.prototype.downloadFile = function(id) {
   return this.throttle(function() {
-    return DriveApp.getFileById(propertiesDocId).getBlob().getDataAsString();
+    return DriveApp.getFileById(id).getBlob().getDataAsString();
   });
 };
 

--- a/lib/GDriveService.js
+++ b/lib/GDriveService.js
@@ -68,7 +68,7 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
  */
 GDriveService.prototype.downloadFile = function(id) {
   return this.throttle(function() {
-    return Drive.Files.get(id, { alt: 'media' });
+    return DriveApp.getFileById(propertiesDocId).getBlob().getDataAsString();
   });
 };
 


### PR DESCRIPTION
When file's title on leftovers contains multi-bytes character,
copied file's title was garbled.
`Drive.Files.get(id, {alt: 'media'})` cannot specify content encoding.
The content encoding is expected UTF-8.
So, `getBlob().getDataAsString()` Instead of `Files.get()`.