### PR TITLE
Process next page token in leftovers

### DIFF
--- a/dist/application.gs
+++ b/dist/application.gs
@@ -473,7 +473,7 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
   return this.throttle(function() {
     return Drive.Files.list({
       q: query,
-      maxResults: 1000,
+      maxResults: 200,
       pageToken: pageToken,
       orderBy: orderBy
     });

--- a/dist/application.gs
+++ b/dist/application.gs
@@ -487,7 +487,9 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
  */
 GDriveService.prototype.downloadFile = function(id) {
   return this.throttle(function() {
-    return DriveApp.getFileById(id).getBlob().getDataAsString();
+    return DriveApp.getFileById(id)
+      .getBlob()
+      .getDataAsString();
   });
 };
 
@@ -1048,6 +1050,14 @@ Util.composeErrorMsg = function(e, customMsg) {
   ];
 };
 
+Util.isNone = function(obj) {
+  return obj === null || obj === undefined;
+};
+
+Util.isSome = function(obj) {
+  return !Util.isNone(obj);
+};
+
 
 /**********************************************
  * Main copy loop
@@ -1150,14 +1160,14 @@ function copy() {
   timer.update(userProperties);
 
   // When leftovers are complete, query next folder from properties.remaining
-  while (properties.remaining.length > 0 && timer.canContinue()) {
+  while (
+    (properties.remaining.length > 0 || Util.isSome(properties.pageToken)) &&
+    timer.canContinue()
+  ) {
     // if pages remained in the previous query, use them first
     if (properties.pageToken) {
       currFolder = properties.destFolder;
     } else {
-      // TODO: This is throwing tons of errors but I don't know why.
-      // for some reason properties.remaining is not being parsed correctly,
-      // so it's a JSON stringy object instead of an actual array.
       try {
         currFolder = properties.remaining.shift();
       } catch (e) {

--- a/dist/application.gs
+++ b/dist/application.gs
@@ -1058,6 +1058,10 @@ Util.isSome = function(obj) {
   return !Util.isNone(obj);
 };
 
+Util.hasSome = function(obj, prop) {
+  return obj && obj[prop] && obj[prop].length > 0;
+};
+
 
 /**********************************************
  * Main copy loop
@@ -1141,11 +1145,7 @@ function copy() {
   // that weren't processed before script timed out.
   // Destination folder must be set to the parent of the first leftover item.
   // The list of leftover items is an equivalent array to fileList returned from the getFiles() query
-  if (
-    properties.leftovers &&
-    properties.leftovers.items &&
-    properties.leftovers.items.length > 0
-  ) {
+  if (Util.hasSome(properties.leftovers, 'items')) {
     properties.destFolder = properties.leftovers.items[0].parents[0].id;
     fileService.processFileList(
       properties.leftovers.items,
@@ -1194,7 +1194,7 @@ function copy() {
       }
 
       // Send items to processFileList() to copy if there is anything to copy
-      if (fileList && fileList.items && fileList.items.length > 0) {
+      if (Util.hasSome(fileList, 'items')) {
         fileService.processFileList(
           fileList.items,
           properties,

--- a/lib/GDriveService.js
+++ b/lib/GDriveService.js
@@ -68,7 +68,9 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
  */
 GDriveService.prototype.downloadFile = function(id) {
   return this.throttle(function() {
-    return DriveApp.getFileById(id).getBlob().getDataAsString();
+    return DriveApp.getFileById(id)
+      .getBlob()
+      .getDataAsString();
   });
 };
 

--- a/lib/GDriveService.js
+++ b/lib/GDriveService.js
@@ -54,7 +54,7 @@ GDriveService.prototype.getFiles = function(query, pageToken, orderBy) {
   return this.throttle(function() {
     return Drive.Files.list({
       q: query,
-      maxResults: 1000,
+      maxResults: 200,
       pageToken: pageToken,
       orderBy: orderBy
     });

--- a/lib/Util.js
+++ b/lib/Util.js
@@ -238,6 +238,10 @@ Util.isSome = function(obj) {
   return !Util.isNone(obj);
 };
 
+Util.hasSome = function(obj, prop) {
+  return obj && obj[prop] && obj[prop].length > 0;
+};
+
 //removeIf(production)
 // Google Apps Script doesn't play well with module.exports,
 // but it is required for testing

--- a/lib/Util.js
+++ b/lib/Util.js
@@ -230,6 +230,14 @@ Util.composeErrorMsg = function(e, customMsg) {
   ];
 };
 
+Util.isNone = function(obj) {
+  return obj === null || obj === undefined;
+};
+
+Util.isSome = function(obj) {
+  return !Util.isNone(obj);
+};
+
 //removeIf(production)
 // Google Apps Script doesn't play well with module.exports,
 // but it is required for testing

--- a/lib/main.js
+++ b/lib/main.js
@@ -80,11 +80,7 @@ function copy() {
   // that weren't processed before script timed out.
   // Destination folder must be set to the parent of the first leftover item.
   // The list of leftover items is an equivalent array to fileList returned from the getFiles() query
-  if (
-    properties.leftovers &&
-    properties.leftovers.items &&
-    properties.leftovers.items.length > 0
-  ) {
+  if (Util.hasSome(properties.leftovers, 'items')) {
     properties.destFolder = properties.leftovers.items[0].parents[0].id;
     fileService.processFileList(
       properties.leftovers.items,
@@ -133,7 +129,7 @@ function copy() {
       }
 
       // Send items to processFileList() to copy if there is anything to copy
-      if (fileList && fileList.items && fileList.items.length > 0) {
+      if (Util.hasSome(fileList, 'items')) {
         fileService.processFileList(
           fileList.items,
           properties,

--- a/lib/main.js
+++ b/lib/main.js
@@ -99,14 +99,14 @@ function copy() {
   timer.update(userProperties);
 
   // When leftovers are complete, query next folder from properties.remaining
-  while (properties.remaining.length > 0 && timer.canContinue()) {
+  while (
+    (properties.remaining.length > 0 || Util.isSome(properties.pageToken)) &&
+    timer.canContinue()
+  ) {
     // if pages remained in the previous query, use them first
     if (properties.pageToken) {
       currFolder = properties.destFolder;
     } else {
-      // TODO: This is throwing tons of errors but I don't know why.
-      // for some reason properties.remaining is not being parsed correctly,
-      // so it's a JSON stringy object instead of an actual array.
       try {
         currFolder = properties.remaining.shift();
       } catch (e) {


### PR DESCRIPTION
Another attempt to fix #67. I believe the issue is occurring when there are leftovers, and the leftovers are processed with time remaining. There is nothing in the script to get the next set of files after the leftovers are processed, therefore it would think it is done before it actually finishes.

Still working on reproducing, but this should be a straight forward fix