### PR TITLE
Skip duplicate ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ lib/*.js
 
 # not sure if this needs to be private or not
 .clasp.json
+.clasp.dev.json
+.clasp.prod.json

--- a/lib/FeatureFlag.ts
+++ b/lib/FeatureFlag.ts
@@ -1,0 +1,5 @@
+const FeatureFlag = {
+  SKIP_DUPLICATE_ID: false
+}
+
+export default FeatureFlag;

--- a/lib/FileService.ts
+++ b/lib/FileService.ts
@@ -11,6 +11,7 @@ import API from './API';
 import MimeType from './MimeType';
 import Constants from './Constants';
 import ErrorMessages from './ErrorMessages';
+import FeatureFlag from './FeatureFlag';
 
 export default class FileService {
   gDriveService: GDriveService;
@@ -220,16 +221,22 @@ export default class FileService {
         continue;
       }
 
-      // if item has already been completed, skip to avoid infinite loop bugs
-      if (this.properties.completed[item.id]) {
-        continue;
+      if (FeatureFlag.SKIP_DUPLICATE_ID) {
+        // if item has already been completed, skip to avoid infinite loop bugs
+        if (this.properties.completed[item.id]) {
+          continue;
+        }
       }
 
       // Copy each (files and folders are both represented the same in Google Drive)
       try {
         var newfile = this.copyFile(item);
-        // record that this file has been processed
-        this.properties.completed[item.id] = true;
+
+        if (FeatureFlag.SKIP_DUPLICATE_ID) {
+          // record that this file has been processed
+          this.properties.completed[item.id] = true;
+        }
+
         // log the new file as successful
         Util.logCopySuccess(ss, newfile, this.properties.timeZone);
       } catch (e) {

--- a/lib/FileService.ts
+++ b/lib/FileService.ts
@@ -220,9 +220,17 @@ export default class FileService {
         continue;
       }
 
+      // if item has already been completed, skip to avoid infinite loop bugs
+      if (this.properties.completed[item.id]) {
+        continue;
+      }
+
       // Copy each (files and folders are both represented the same in Google Drive)
       try {
         var newfile = this.copyFile(item);
+        // record that this file has been processed
+        this.properties.completed[item.id] = true;
+        // log the new file as successful
         Util.logCopySuccess(ss, newfile, this.properties.timeZone);
       } catch (e) {
         this.properties.retryQueue.unshift({

--- a/lib/Properties.ts
+++ b/lib/Properties.ts
@@ -27,6 +27,7 @@ export default class Properties {
   totalRuntime: number;
   pageToken?: string;
   isOverMaxRuntime?: boolean;
+  completed: object;
 
   constructor(gDriveService: GDriveService) {
     this.gDriveService = gDriveService;
@@ -46,6 +47,7 @@ export default class Properties {
     this.remaining = [];
     this.timeZone = 'GMT-7';
     this.totalRuntime = 0;
+    this.completed = {};
 
     return this;
   }

--- a/test/FileService.test.js
+++ b/test/FileService.test.js
@@ -717,51 +717,33 @@ describe('FileService', function() {
       stubLog.restore();
     });
 
-    describe('when FeatureFlag.SKIP_DUPLICATE_ID is on', function() {
-      it('should not copy the same ID twice', function() {
-        // set up mocks
-        FeatureFlag.SKIP_DUPLICATE_ID = true
-        const stubCopy = sinon
-          .stub(this.fileService, 'copyFile')
-          .returns(this.mockFile);
-        Util.logCopySuccess = sinon.stub();
+    [
+      [true, 'not ', 3],
+      [false, '', 4],
+    ].forEach(([featureFlag, not, numberCopies]) => {
+      describe(`when FeatureFlag.SKIP_DUPLICATE_ID is ${featureFlag}`, function() {
+        it(`should ${not}copy the same ID twice`, function() {
+          // set up mocks
+          FeatureFlag.SKIP_DUPLICATE_ID = featureFlag
+          const stubCopy = sinon
+            .stub(this.fileService, 'copyFile')
+            .returns(this.mockFile);
+          Util.logCopySuccess = sinon.stub();
 
-        // run actual
-        const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
-        this.fileService.processFileList(items, this.userProperties, {
-          spreadsheetStub: true
-        });
+          // run actual
+          const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
+          this.fileService.processFileList(items, this.userProperties, {
+            spreadsheetStub: true
+          });
 
-        // assertions
-        assert.equal(stubCopy.callCount, 3, `stubCopy not called 3 times`);
+          // assertions
+          assert.equal(stubCopy.callCount, numberCopies, `stubCopy not called ${numberCopies} times`);
 
-        // restore mocks
-        stubCopy.restore();
-      });
-    });
-
-    describe('when FeatureFlag.SKIP_DUPLICATE_ID is off', function() {
-      it('should copy the same ID twice', function() {
-        // set up mocks
-        FeatureFlag.SKIP_DUPLICATE_ID = false
-        const stubCopy = sinon
-          .stub(this.fileService, 'copyFile')
-          .returns(this.mockFile);
-        Util.logCopySuccess = sinon.stub();
-
-        // run actual
-        const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
-        this.fileService.processFileList(items, this.userProperties, {
-          spreadsheetStub: true
-        });
-
-        // assertions
-        assert.equal(stubCopy.callCount, 4, `stubCopy not called 4 times`);
-
-        // restore mocks
-        stubCopy.restore();
-      });
-    });
+          // restore mocks
+          stubCopy.restore();
+        })
+      })
+    })
   });
 
   describe('isDescendant()', function() {

--- a/test/FileService.test.js
+++ b/test/FileService.test.js
@@ -685,7 +685,7 @@ describe('FileService', function() {
       const stubLog = sinon.stub(Util, 'logCopySuccess');
 
       // run actual
-      const items = [1, 2, 3];
+      const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
       const itemsLength = items.length; // must set here because items is mutated in processFileList
       this.fileService.processFileList(items, this.userProperties, {
         spreadsheetStub: true
@@ -696,7 +696,7 @@ describe('FileService', function() {
       assert.equal(
         stubLog.callCount,
         itemsLength,
-        'Util.logCopySuccess not called once'
+        `Util.logCopySuccess not called ${itemsLength} times`
       );
       assert.equal(
         stubLog.getCall(0).args[0].spreadsheetStub,
@@ -714,6 +714,26 @@ describe('FileService', function() {
       // restore mocks
       stubCopy.restore();
       stubLog.restore();
+    });
+
+    it('should not copy the same ID twice', function() {
+      // set up mocks
+      const stubCopy = sinon
+        .stub(this.fileService, 'copyFile')
+        .returns(this.mockFile);
+      Logging.logCopySuccess = sinon.stub();
+
+      // run actual
+      const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
+      this.fileService.processFileList(items, {
+        spreadsheetStub: true
+      });
+
+      // assertions
+      assert.equal(stubCopy.callCount, 3, `stubCopy not called 2 times`);
+
+      // restore mocks
+      stubCopy.restore();
     });
   });
 

--- a/test/FileService.test.js
+++ b/test/FileService.test.js
@@ -716,24 +716,26 @@ describe('FileService', function() {
       stubLog.restore();
     });
 
-    it('should not copy the same ID twice', function() {
-      // set up mocks
-      const stubCopy = sinon
-        .stub(this.fileService, 'copyFile')
-        .returns(this.mockFile);
-      Logging.logCopySuccess = sinon.stub();
+    describe('when FeatureFlag.SKIP_DUPLICATE_ID is on', function() {
+      it('should not copy the same ID twice', function() {
+        // set up mocks
+        const stubCopy = sinon
+          .stub(this.fileService, 'copyFile')
+          .returns(this.mockFile);
+        Util.logCopySuccess = sinon.stub();
 
-      // run actual
-      const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
-      this.fileService.processFileList(items, {
-        spreadsheetStub: true
+        // run actual
+        const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
+        this.fileService.processFileList(items, this.userProperties, {
+          spreadsheetStub: true
+        });
+
+        // assertions
+        assert.equal(stubCopy.callCount, 3, `stubCopy not called 2 times`);
+
+        // restore mocks
+        stubCopy.restore();
       });
-
-      // assertions
-      assert.equal(stubCopy.callCount, 3, `stubCopy not called 2 times`);
-
-      // restore mocks
-      stubCopy.restore();
     });
   });
 

--- a/test/FileService.test.js
+++ b/test/FileService.test.js
@@ -5,6 +5,7 @@ import { Util } from '../lib/Util';
 import Timer from '../lib/Timer';
 import Properties from '../lib/Properties';
 import Constants from '../lib/Constants';
+import FeatureFlag from '../lib/FeatureFlag';
 const PropertiesService = require('./mocks/PropertiesService');
 const assert = require('assert');
 const fs = require('fs');
@@ -719,6 +720,7 @@ describe('FileService', function() {
     describe('when FeatureFlag.SKIP_DUPLICATE_ID is on', function() {
       it('should not copy the same ID twice', function() {
         // set up mocks
+        FeatureFlag.SKIP_DUPLICATE_ID = true
         const stubCopy = sinon
           .stub(this.fileService, 'copyFile')
           .returns(this.mockFile);
@@ -731,7 +733,30 @@ describe('FileService', function() {
         });
 
         // assertions
-        assert.equal(stubCopy.callCount, 3, `stubCopy not called 2 times`);
+        assert.equal(stubCopy.callCount, 3, `stubCopy not called 3 times`);
+
+        // restore mocks
+        stubCopy.restore();
+      });
+    });
+
+    describe('when FeatureFlag.SKIP_DUPLICATE_ID is off', function() {
+      it('should copy the same ID twice', function() {
+        // set up mocks
+        FeatureFlag.SKIP_DUPLICATE_ID = false
+        const stubCopy = sinon
+          .stub(this.fileService, 'copyFile')
+          .returns(this.mockFile);
+        Util.logCopySuccess = sinon.stub();
+
+        // run actual
+        const items = [{ id: 1 }, { id: 2 }, { id: 1 }, { id: 3 }];
+        this.fileService.processFileList(items, this.userProperties, {
+          spreadsheetStub: true
+        });
+
+        // assertions
+        assert.equal(stubCopy.callCount, 4, `stubCopy not called 4 times`);
 
         // restore mocks
         stubCopy.restore();

--- a/test/Properties.test.js
+++ b/test/Properties.test.js
@@ -15,6 +15,7 @@ describe('Properties', function() {
       .readFileSync('test/mocks/properties_document_stringified.txt')
       .toString();
   });
+
   describe('load()', function() {
     it('should assign properties to `this`', function() {
       // set up mocks
@@ -34,6 +35,7 @@ describe('Properties', function() {
       // reset mocks
       stubFile.restore();
     });
+
     it('should return parsing error if not JSON-parsable', function() {
       // set up mocks
       const stubFile = sinon.stub(this.gDriveService, 'downloadFile');
@@ -51,6 +53,7 @@ describe('Properties', function() {
       // reset mocks
       stubFile.restore();
     });
+
     it('should return human readable error if propertiesDocID is undefined', function() {
       // set up mocks
       const stubFile = sinon.stub(this.gDriveService, 'downloadFile');
@@ -69,6 +72,7 @@ describe('Properties', function() {
       stubFile.restore();
     });
   });
+
   describe('save()', function() {
     it('should throw critical error if properties cannot be serialized', function() {
       function Circular() {
@@ -84,6 +88,7 @@ describe('Properties', function() {
         'Failed to serialize script properties. This is a critical failure. Please start your copy again.'
       );
     });
+
     it('should update file with stringified props', function() {
       // set up mocks
       const stubUpdate = sinon.stub(this.gDriveService, 'updateFile');
@@ -111,6 +116,7 @@ describe('Properties', function() {
       );
     });
   });
+
   it('should increment totalRuntime', function() {
     this.properties.incrementTotalRuntime(50);
     assert.equal(
@@ -119,6 +125,7 @@ describe('Properties', function() {
       'totalRuntime not incremented properly'
     );
   });
+
   it('should determine if max runtime is exceeded', function() {
     assert(
       !this.properties.checkMaxRuntime(),

--- a/test/mocks/properties_document_stringified.txt
+++ b/test/mocks/properties_document_stringified.txt
@@ -12,6 +12,7 @@
 	"timeZone": "GMT-7",
 	"retryQueue": [],
 	"totalRuntime": 0,
+	"completed": {},
 	"leftovers": {
 		"kind": "drive#fileList",
 		"selfLink": "https://www.googleapis.com/drive/v2/files?maxResults=1000&q=%220BylyXjPAb3M1NWNjUjBhZzhJOUE%22+in+parents+and+trashed+%3D+false&alt=json",


### PR DESCRIPTION
Implemented originally in #97 but reverted in #99 due to some odd bugs reported by users shortly after deployment.

I don't think the original issue was caused by this update, but regardless I've made the choice to wrap new functionality in feature flags for more easy toggling of features in something breaks in the future.

This should be very safe to deploy but going to wait a bit to ensure the CLASP update isn't causing issues in production.