### PR TITLE
Add logging class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ lib/*.js
 
 # not sure if this needs to be private or not
 .clasp.json
+.clasp.dev.json
+.clasp.prod.json

--- a/lib/FileService.ts
+++ b/lib/FileService.ts
@@ -2,7 +2,7 @@
  * Namespace for file-related functions
  **********************************************/
 
-import { Util } from './Util';
+import Util from './Util';
 import { getMetadata } from './public';
 import Properties from './Properties';
 import Timer from './Timer';
@@ -11,6 +11,7 @@ import API from './API';
 import MimeType from './MimeType';
 import Constants from './Constants';
 import ErrorMessages from './ErrorMessages';
+import Logging from './util/Logging';
 
 export default class FileService {
   gDriveService: GDriveService;
@@ -85,7 +86,7 @@ export default class FileService {
     try {
       permissions = this.gDriveService.getPermissions(srcId).items;
     } catch (e) {
-      Util.log({ status: Util.composeErrorMsg(e) });
+      Logging.log({ status: Util.composeErrorMsg(e) });
     }
 
     // copy editors, viewers, and commenters from src file to dest file
@@ -149,7 +150,7 @@ export default class FileService {
     try {
       destPermissions = this.gDriveService.getPermissions(destId).items;
     } catch (e) {
-      Util.log({ status: Util.composeErrorMsg(e) });
+      Logging.log({ status: Util.composeErrorMsg(e) });
     }
 
     if (destPermissions && destPermissions.length > 0) {
@@ -216,14 +217,14 @@ export default class FileService {
         item.numberOfAttempts &&
         item.numberOfAttempts > this.maxNumberOfAttempts
       ) {
-        Util.logCopyError(ss, item.error, item, this.properties.timeZone);
+        Logging.logCopyError(ss, item.error, item, this.properties.timeZone);
         continue;
       }
 
       // Copy each (files and folders are both represented the same in Google Drive)
       try {
         var newfile = this.copyFile(item);
-        Util.logCopySuccess(ss, newfile, this.properties.timeZone);
+        Logging.logCopySuccess(ss, newfile, this.properties.timeZone);
       } catch (e) {
         this.properties.retryQueue.unshift({
           id: item.id,

--- a/lib/TriggerService.ts
+++ b/lib/TriggerService.ts
@@ -2,8 +2,9 @@
  * Namespace for trigger-related methods
  **********************************************/
 
-import { Util } from './Util';
+import Util from './Util';
 import Timer from './Timer';
+import Logging from './util/Logging';
 
 export default class TriggerService {
   /**
@@ -46,7 +47,7 @@ export default class TriggerService {
           }
         }
       } catch (e) {
-        Util.log({ status: Util.composeErrorMsg(e) });
+        Logging.log({ status: Util.composeErrorMsg(e) });
       }
     }
   }

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -9,161 +9,9 @@ import GDriveService from './GDriveService';
 import Timer from './Timer';
 import Constants from './Constants';
 import ErrorMessages from './ErrorMessages';
+import Logging from './util/Logging';
 
-// credit: https://stackoverflow.com/a/18650828
-export function bytesToHumanReadable(bytes: number = 0, decimals: number = 2) {
-  if (bytes === 0 || bytes === null || bytes === undefined) return '';
-  const unit = 1024;
-  const abbreviations = [
-    'bytes',
-    'KB',
-    'MB',
-    'GB',
-    'TB',
-    'PB',
-    'EB',
-    'ZB',
-    'YB'
-  ];
-  const size = Math.floor(Math.log(bytes) / Math.log(unit));
-  return (
-    parseFloat((bytes / Math.pow(unit, size)).toFixed(decimals)) +
-    ' ' +
-    abbreviations[size]
-  );
-}
-
-export class Util {
-  /**
-   * Logs values to the logger spreadsheet
-   */
-  static _log(
-    ss: GoogleAppsScript.Spreadsheet.Sheet = Util.getDefaultSheet(),
-    values: string[]
-  ): void {
-    // avoid placing entries that are too long
-    values = values.map(function(cell) {
-      if (cell && typeof cell == 'string') {
-        return cell.slice(0, 4999);
-      }
-      return '';
-    });
-
-    // gets last row with content.
-    // getMaxRows() gets returns the current number of rows in the sheet, regardless of content.
-    var lastRow = ss.getLastRow();
-    var startRow = lastRow + 1;
-    var startColumn = 1; // columns are 1-indexed
-    var numRows = 1;
-    var numColumns = values.length;
-
-    try {
-      ss
-        // 2018-02-23: fix `Service Error: Spreadsheets`
-        // Ensure that we don't try to insert to a row that doesn't exist
-        // resource: https://stackoverflow.com/questions/23165101/service-error-spreadsheets-on-google-scripts
-        .insertRowAfter(lastRow)
-        .getRange(startRow, startColumn, numRows, numColumns)
-        // setValues needs a 2-dimensional array in case you are inserting multiple rows.
-        // we always log one row at a time, though this could be changed in the future.
-        .setValues([values]);
-    } catch (e) {
-      // Google sheets doesn't allow inserting more than 2,000,000 rows into a spreadsheet
-      ss.getRange(lastRow, startColumn, numRows, 1).setValues([
-        [ErrorMessages.SpreadsheetTooLarge]
-      ]);
-    }
-  }
-
-  static getDefaultSheet(): GoogleAppsScript.Spreadsheet.Sheet {
-    return SpreadsheetApp.openById(
-      PropertiesService.getUserProperties().getProperty('spreadsheetId')
-    ).getSheetByName('Log');
-  }
-
-  static log({
-    ss = Util.getDefaultSheet(),
-    status = '',
-    title = '',
-    id = '',
-    timeZone = 'GMT-7',
-    parentId = '',
-    fileSize = 0
-  }: {
-    ss?: GoogleAppsScript.Spreadsheet.Sheet;
-    status?: string;
-    title?: string;
-    id?: string;
-    timeZone?: string;
-    parentId?: string;
-    fileSize?: number;
-  }) {
-    // map column names to indices
-    const columns = {
-      status: 0,
-      title: 1,
-      link: 2,
-      id: 3,
-      timeCompleted: 4,
-      parentFolderLink: 5,
-      fileSize: 6
-    };
-
-    // set values to array of empty strings, then assign value based on column index
-    const values = Object.keys(columns).map(_ => '');
-    values[columns.status] = status;
-    values[columns.title] = title;
-    values[columns.link] = FileService.getFileLinkForSheet(id, title);
-    values[columns.id] = id;
-    values[columns.timeCompleted] = Utilities.formatDate(
-      new Date(),
-      timeZone,
-      'MM-dd-yy hh:mm:ss aaa'
-    );
-    values[columns.parentFolderLink] =
-      parentId === ''
-        ? parentId
-        : FileService.getFileLinkForSheet(parentId, '');
-    values[columns.fileSize] = bytesToHumanReadable(fileSize);
-
-    // log values
-    Util._log(ss, values);
-  }
-
-  static logCopyError(
-    ss: GoogleAppsScript.Spreadsheet.Sheet,
-    error: Error,
-    item: gapi.client.drive.FileResource,
-    timeZone: string
-  ): void {
-    var parentId = item.parents && item.parents[0] ? item.parents[0].id : null;
-    Util.log({
-      ss,
-      status: Util.composeErrorMsg(error),
-      title: item.title,
-      id: item.id,
-      timeZone,
-      parentId
-    });
-  }
-
-  static logCopySuccess(
-    ss: GoogleAppsScript.Spreadsheet.Sheet,
-    item: gapi.client.drive.FileResource,
-    timeZone: string
-  ): void {
-    var parentId = item.parents && item.parents[0] ? item.parents[0].id : null;
-    Util.log({
-      ss,
-      status: 'Copied',
-      title: item.title,
-      id: item.id,
-      timeZone,
-      parentId,
-      fileSize: item.fileSize
-    });
-  }
-
+export default class Util {
   /**
    * Invokes a function, performing up to 5 retries with exponential backoff.
    * Retries with delays of approximately 1, 2, 4, 8 then 16 seconds for a total of
@@ -176,9 +24,9 @@ export class Util {
       try {
         return func();
       } catch (e) {
-        Util.log({ status: Util.composeErrorMsg(e) });
+        Logging.log({ status: Util.composeErrorMsg(e) });
         if (n == 5) {
-          Util.log({
+          Logging.log({
             status: errorMsg
           });
           throw e;
@@ -206,7 +54,7 @@ export class Util {
         fileList && fileList.items ? fileList : properties.leftovers;
       properties.pageToken = properties.leftovers.nextPageToken;
     } catch (e) {
-      Util.log({
+      Logging.log({
         ss,
         status: Util.composeErrorMsg(e, ErrorMessages.FailedSetLeftovers)
       });
@@ -226,18 +74,18 @@ export class Util {
         } catch (e) {
           // likely already deleted, shouldn't be a big deal
         }
-        Util.log({ ss, status: ErrorMessages.OutOfSpace });
-        Util.log({ ss, status: ErrorMessages.WillDuplicateOnResume });
+        Logging.log({ ss, status: ErrorMessages.OutOfSpace });
+        Logging.log({ ss, status: ErrorMessages.WillDuplicateOnResume });
         // return early to prevent logging `logMessage`
         return;
       }
-      Util.log({
+      Logging.log({
         ss,
         status: Util.composeErrorMsg(e, ErrorMessages.FailedSaveProperties)
       });
     }
 
-    Util.log({
+    Logging.log({
       ss,
       status: logMessage
     });
@@ -283,7 +131,7 @@ export class Util {
           properties.propertiesDocId
         );
       } catch (e) {
-        Util.log({
+        Logging.log({
           ss,
           status: Util.composeErrorMsg(e)
         });

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -4,11 +4,12 @@
 
 import FileService from './FileService';
 import GDriveService from './GDriveService';
-import { Util } from './Util';
+import Util from './Util';
 import Properties from './Properties';
 import Timer from './Timer';
 import TriggerService from './TriggerService';
 import ErrorMessages from './ErrorMessages';
+import Logging from './util/Logging';
 
 /**
  * Copy folders and files from source to destination.
@@ -104,7 +105,7 @@ export function copy(): void {
       try {
         fileList = gDriveService.getFiles(query, properties.pageToken);
       } catch (e) {
-        Util.log({ ss, status: Util.composeErrorMsg(e) });
+        Logging.log({ ss, status: Util.composeErrorMsg(e) });
       }
       if (!fileList) {
         console.log('fileList is undefined. currFolder:', currFolder);

--- a/lib/public.ts
+++ b/lib/public.ts
@@ -92,7 +92,7 @@ export function initialize(
     options.timeZone = 'GMT-7';
   }
 
-  // Adding a row to status list prevents weird style copying in Util.log
+  // Adding a row to status list prevents weird style copying when logging
   try {
     SpreadsheetApp.openById(spreadsheet.id)
       .getSheetByName('Log')

--- a/lib/util/Logging.ts
+++ b/lib/util/Logging.ts
@@ -1,0 +1,159 @@
+import FileService from '../FileService';
+import Util from '../Util';
+import ErrorMessages from '../ErrorMessages';
+
+// would be nice to call this "Logger" but that already exists in the Google Apps Script namespace
+export default class Logging {
+  /**
+   * Logs values to the logger spreadsheet
+   */
+  static _log(
+    ss: GoogleAppsScript.Spreadsheet.Sheet = Logging.getDefaultSheet(),
+    values: string[]
+  ): void {
+    // avoid placing entries that are too long
+    values = values.map(function(cell) {
+      if (cell && typeof cell == 'string') {
+        return cell.slice(0, 4999);
+      }
+      return '';
+    });
+
+    // gets last row with content.
+    // getMaxRows() gets returns the current number of rows in the sheet, regardless of content.
+    var lastRow = ss.getLastRow();
+    var startRow = lastRow + 1;
+    var startColumn = 1; // columns are 1-indexed
+    var numRows = 1;
+    var numColumns = values.length;
+
+    try {
+      ss
+        // 2018-02-23: fix `Service Error: Spreadsheets`
+        // Ensure that we don't try to insert to a row that doesn't exist
+        // resource: https://stackoverflow.com/questions/23165101/service-error-spreadsheets-on-google-scripts
+        .insertRowAfter(lastRow)
+        .getRange(startRow, startColumn, numRows, numColumns)
+        // setValues needs a 2-dimensional array in case you are inserting multiple rows.
+        // we always log one row at a time, though this could be changed in the future.
+        .setValues([values]);
+    } catch (e) {
+      // Google sheets doesn't allow inserting more than 2,000,000 rows into a spreadsheet
+      ss.getRange(lastRow, startColumn, numRows, 1).setValues([
+        [ErrorMessages.SpreadsheetTooLarge]
+      ]);
+    }
+  }
+
+  static getDefaultSheet(): GoogleAppsScript.Spreadsheet.Sheet {
+    return SpreadsheetApp.openById(
+      PropertiesService.getUserProperties().getProperty('spreadsheetId')
+    ).getSheetByName('Log');
+  }
+
+  static log({
+    ss = Logging.getDefaultSheet(),
+    status = '',
+    title = '',
+    id = '',
+    timeZone = 'GMT-7',
+    parentId = '',
+    fileSize = 0
+  }: {
+    ss?: GoogleAppsScript.Spreadsheet.Sheet;
+    status?: string;
+    title?: string;
+    id?: string;
+    timeZone?: string;
+    parentId?: string;
+    fileSize?: number;
+  }) {
+    // map column names to indices
+    const columns = {
+      status: 0,
+      title: 1,
+      link: 2,
+      id: 3,
+      timeCompleted: 4,
+      parentFolderLink: 5,
+      fileSize: 6
+    };
+
+    // set values to array of empty strings, then assign value based on column index
+    const values = Object.keys(columns).map(_ => '');
+    values[columns.status] = status;
+    values[columns.title] = title;
+    values[columns.link] = FileService.getFileLinkForSheet(id, title);
+    values[columns.id] = id;
+    values[columns.timeCompleted] = Utilities.formatDate(
+      new Date(),
+      timeZone,
+      'MM-dd-yy hh:mm:ss aaa'
+    );
+    values[columns.parentFolderLink] =
+      parentId === ''
+        ? parentId
+        : FileService.getFileLinkForSheet(parentId, '');
+    values[columns.fileSize] = Logging.bytesToHumanReadable(fileSize);
+
+    // log values
+    Logging._log(ss, values);
+  }
+
+  static logCopyError(
+    ss: GoogleAppsScript.Spreadsheet.Sheet,
+    error: Error,
+    item: gapi.client.drive.FileResource,
+    timeZone: string
+  ): void {
+    var parentId = item.parents && item.parents[0] ? item.parents[0].id : null;
+    Logging.log({
+      ss,
+      status: Util.composeErrorMsg(error),
+      title: item.title,
+      id: item.id,
+      timeZone,
+      parentId
+    });
+  }
+
+  static logCopySuccess(
+    ss: GoogleAppsScript.Spreadsheet.Sheet,
+    item: gapi.client.drive.FileResource,
+    timeZone: string
+  ): void {
+    var parentId = item.parents && item.parents[0] ? item.parents[0].id : null;
+    Logging.log({
+      ss,
+      status: 'Copied',
+      title: item.title,
+      id: item.id,
+      timeZone,
+      parentId,
+      fileSize: item.fileSize
+    });
+  }
+
+  // credit: https://stackoverflow.com/a/18650828
+  static bytesToHumanReadable(bytes: number = 0, decimals: number = 2) {
+    if (bytes === 0 || bytes === null || bytes === undefined) return '';
+    const unit = 1024;
+    const abbreviations = [
+      'bytes',
+      'KB',
+      'MB',
+      'GB',
+      'TB',
+      'PB',
+      'EB',
+      'ZB',
+      'YB'
+    ];
+    const size = Math.floor(Math.log(bytes) / Math.log(unit));
+    return (
+      parseFloat((bytes / Math.pow(unit, size)).toFixed(decimals)) +
+      ' ' +
+      abbreviations[size]
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "pretest": "tsc lib/*.ts --module commonjs || true",
-    "posttest": "rm lib/*.js",
+    "posttest": "rm lib/*.js && rm lib/**/*.js",
     "test": "nyc mocha --grep formatting --invert --compilers js:babel-core/register",
     "prettier-test": "mocha test/formatting/prettier.test.js --compilers js:babel-core/register",
     "watch": "gulp watch",

--- a/test/FileService.test.js
+++ b/test/FileService.test.js
@@ -1,10 +1,10 @@
 global.Utilities = require('./mocks/Utilities');
 import FileService from '../lib/FileService';
 import GDriveService from '../lib/GDriveService';
-import { Util } from '../lib/Util';
 import Timer from '../lib/Timer';
 import Properties from '../lib/Properties';
 import Constants from '../lib/Constants';
+import Logging from '../lib/util/Logging';
 const PropertiesService = require('./mocks/PropertiesService');
 const assert = require('assert');
 const fs = require('fs');
@@ -487,7 +487,7 @@ describe('FileService', function() {
       const stubCopy = sinon
         .stub(this.fileService, 'copyFile')
         .returns(this.mockFile);
-      const stubLog = sinon.stub(Util, 'log');
+      const stubLog = sinon.stub(Logging, 'log');
       const stubCopyPermissions = sinon.stub(
         this.fileService,
         'copyPermissions'
@@ -520,7 +520,7 @@ describe('FileService', function() {
       const stubCopy = sinon
         .stub(this.fileService, 'copyFile')
         .returns(this.mockFile);
-      const stubLog = sinon.stub(Util, 'log');
+      const stubLog = sinon.stub(Logging, 'log');
       const stubCopyPermissions = sinon.stub(
         this.fileService,
         'copyPermissions'
@@ -553,7 +553,7 @@ describe('FileService', function() {
       const stubCopy = sinon
         .stub(this.fileService, 'copyFile')
         .returns(this.mockFile);
-      const stubLog = sinon.stub(Util, 'log');
+      const stubLog = sinon.stub(Logging, 'log');
       const stubCopyPermissions = sinon.stub(
         this.fileService,
         'copyPermissions'
@@ -637,7 +637,7 @@ describe('FileService', function() {
       const stubCopy = sinon
         .stub(this.fileService, 'copyFile')
         .throws(new Error(errMsg));
-      const stubLog = sinon.stub(Util, 'logCopyError');
+      const stubLog = sinon.stub(Logging, 'logCopyError');
 
       // run actual
       const previouslyRetriedFile = Object.assign({}, this.mockFile, {
@@ -650,20 +650,20 @@ describe('FileService', function() {
       });
 
       // assertions
-      assert(stubLog.called, 'Util.logCopyError not called');
+      assert(stubLog.called, 'Logging.logCopyError not called');
       assert.equal(
         stubLog.callCount,
         1,
-        'Util.log called incorrect number of times'
+        'Logging.log called incorrect number of times'
       );
       assert(
         stubLog.getCall(0).args[0].spreadsheetStub,
-        'Util.logCopyError not called with spreadsheetStub'
+        'Logging.logCopyError not called with spreadsheetStub'
       );
       assert.equal(
         stubLog.getCall(0).args[1].message,
         errMsg,
-        'Error not passed to Util.logCopyError correctly'
+        'Error not passed to Logging.logCopyError correctly'
       );
       assert.equal(stubLog.getCall(0).args[2].id, previouslyRetriedFile.id);
       assert.equal(
@@ -682,7 +682,7 @@ describe('FileService', function() {
       const stubCopy = sinon
         .stub(this.fileService, 'copyFile')
         .returns(this.mockFile);
-      const stubLog = sinon.stub(Util, 'logCopySuccess');
+      const stubLog = sinon.stub(Logging, 'logCopySuccess');
 
       // run actual
       const items = [1, 2, 3];
@@ -692,22 +692,22 @@ describe('FileService', function() {
       });
 
       // assertions
-      assert(stubLog.called, 'Util.logCopySuccess not called.');
+      assert(stubLog.called, 'Logging.logCopySuccess not called.');
       assert.equal(
         stubLog.callCount,
         itemsLength,
-        'Util.logCopySuccess not called once'
+        'Logging.logCopySuccess not called once'
       );
       assert.equal(
         stubLog.getCall(0).args[0].spreadsheetStub,
         true,
-        'Util.logCopySuccess not called with "spreadsheetStub". Called with ' +
+        'Logging.logCopySuccess not called with "spreadsheetStub". Called with ' +
           stubLog.getCall(0).args[0]
       );
       assert.deepEqual(
         stubLog.getCall(0).args[1],
         this.mockFile,
-        'Util.logCopySuccess not called with "this.mockFile". Called with ' +
+        'Logging.logCopySuccess not called with "this.mockFile". Called with ' +
           stubLog.getCall(0).args[1]
       );
 

--- a/test/Util.test.js
+++ b/test/Util.test.js
@@ -1,9 +1,10 @@
 global.Utilities = require('./mocks/Utilities');
-import { Util } from '../lib/Util';
+import Util from '../lib/Util';
 import Timer from '../lib/Timer';
 import TriggerService from '../lib/TriggerService';
 import Properties from '../lib/Properties';
 import Constants from '../lib/Constants';
+import Logging from '../lib/util/Logging';
 const userProperties = require('./mocks/PropertiesService').getUserProperties();
 const sinon = require('sinon');
 const assert = require('assert');
@@ -14,7 +15,7 @@ describe('Util', function() {
       // set up mocks
       const errMsg = 'i failed';
       const failingFunc = sinon.stub().throws(errMsg);
-      const stubLog = sinon.stub(Util, 'log');
+      const stubLog = sinon.stub(Logging, 'log');
 
       const failingFunc2 = () => {
         throw new Error(errMsg);
@@ -27,7 +28,7 @@ describe('Util', function() {
 
       // assertions
       assert.equal(failingFunc.callCount, 6, 'failing func not called 6 times');
-      assert.equal(stubLog.callCount, 7, 'Util.log not called 7 times');
+      assert.equal(stubLog.callCount, 7, 'Logging.log not called 7 times');
 
       // reset mocks
       stubLog.restore();
@@ -35,7 +36,7 @@ describe('Util', function() {
     it('should rethrow error after 6 tries', function() {
       // set up mocks
       const errMsg = 'i failed';
-      const stubLog = sinon.stub(Util, 'log');
+      const stubLog = sinon.stub(Logging, 'log');
       const failingFunc2 = () => {
         throw new Error(errMsg);
       };

--- a/test/toHumanReadable.test.js
+++ b/test/toHumanReadable.test.js
@@ -1,41 +1,41 @@
-import { bytesToHumanReadable } from '../lib/Util';
 import * as assert from 'assert';
+import Logging from '../lib/util/Logging';
 
 describe('bytesToHumanReadable', function() {
   it('should return bytes when less than 1 KB', () => {
     const number = 124;
-    const actual = bytesToHumanReadable(number);
+    const actual = Logging.bytesToHumanReadable(number);
     assert.equal(actual, '124 bytes');
   });
 
   it('should return KB when 1KB <= size < 1MB', () => {
     const number = 12442;
-    const actual = bytesToHumanReadable(number);
+    const actual = Logging.bytesToHumanReadable(number);
     assert.equal(actual, '12.15 KB');
   });
 
   it('should return MB when 1MB <= size <= 1GB', () => {
     const number = 12442873;
-    const actual = bytesToHumanReadable(number);
+    const actual = Logging.bytesToHumanReadable(number);
     assert.equal(actual, '11.87 MB');
   });
 
   it('should return GB when 1GB <= size < 1TB', () => {
     const number = 12442125346;
-    const actual = bytesToHumanReadable(number);
+    const actual = Logging.bytesToHumanReadable(number);
     assert.equal(actual, '11.59 GB');
   });
 
   it('should return TB when 1TB <= size < 1PB', () => {
     const number = 12442125346125;
-    const actual = bytesToHumanReadable(number);
+    const actual = Logging.bytesToHumanReadable(number);
     assert.equal(actual, '11.32 TB');
   });
 
   // does google drive even support files this large? :P
   it('should return PB when 1PB <= size < 1EB', () => {
     const number = 12442125346125124;
-    const actual = bytesToHumanReadable(number);
+    const actual = Logging.bytesToHumanReadable(number);
     assert.equal(actual, '11.05 PB');
   });
 });


### PR DESCRIPTION
Implemented originally in #89 and then reverted in #103 

Reducing the scale of the PR dramatically: rather than adding a quota manager, just extracting logging logic into a new class. High level goal is to continue breaking apart this huge monolithic classes making the program a bit easier to reason about and troubleshoot.

This should be safe to merge but want to wait until CLASP stuff is settled a bit and make sure no new issues arise.